### PR TITLE
Asynchronous query interface

### DIFF
--- a/pandas_td/__init__.py
+++ b/pandas_td/__init__.py
@@ -2,7 +2,9 @@ from .td import connect
 from .td import create_engine
 from .td import read_td
 from .td import read_td_query
+from .td import read_td_result
 from .td import read_td_table
+from .td import td_query
 from .td import to_td
 
 __all__ = [
@@ -10,6 +12,8 @@ __all__ = [
     'create_engine',
     'read_td',
     'read_td_query',
+    'read_td_result',
     'read_td_table',
+    'td_query',
     'to_td',
 ]


### PR DESCRIPTION
Because jobs on Treasure Data may take time to finish, it'd be nice if it is possible to run multiple jobs asynchronously, especially when using interactive shell such like IPython. I added `td_query` and `read_td_result` to run multiple jobs asynchronously.

```python
import pandas_td as td
con = td.connect()
engine = con.query_engine(database='sample_datasets', type='hive')
r = td.td_query("SELECT symbol, COUNT(1) FROM nasdaq GROUP BY symbol", engine)
td.read_td_result(r, engine)
```