### PR TITLE
Specify maximum allowed version of requests as workaround of #7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ tzlocal
 futures>=3.0.3
 six>=1.9.0
 pandas>=0.16.0
-requests>=2.7.0
+requests>=2.7.0,<2.16.0
 td-client>=0.4.0


### PR DESCRIPTION
Workaround of `requests` version issue reported as #7. Tweaked declaration of dependency versions to make the library working.

cc: @kamikaseda 