### PR TITLE
fix: set minimum requests version to 2.21.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ tzlocal
 futures>=3.0.3
 six>=1.9.0
 pandas>=0.16.0
-requests>=2.7.0,<2.16.0
+requests>=2.21.0
 td-client>=0.4.0


### PR DESCRIPTION
This modification should be aligned with https://github.com/treasure-data/td-client-python/pull/51 to aviod https://github.com/treasure-data/pandas-td/issues/7