### PR TITLE
Add a link to pytd as pandas-td alternative

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Pandas-TD
+**NOTICE: pandas-td will be no longer maintained after June, 2019. Use [pytd](https://github.com/takuti/pytd) instead.** 
+
+The alternative tool offers pandas-td-compatible functions that provide the same functionalities in a more efficient way.
+
+# Pandas-TD [deprecated]
 
 [![Build Status](https://travis-ci.org/treasure-data/pandas-td.svg?branch=master)](https://travis-ci.org/treasure-data/pandas-td)
 [![Code Health](https://landscape.io/github/treasure-data/pandas-td/master/landscape.svg?style=flat)](https://landscape.io/github/treasure-data/pandas-td/master)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**NOTICE: pandas-td will be no longer maintained after June, 2019. Use [pytd](https://github.com/takuti/pytd) instead.** 
+**NOTICE: pandas-td will be no longer maintained after June, 2019. Use [pytd](https://github.com/treasure-data/pytd) instead.** 
 
 The alternative tool offers pandas-td-compatible functions that provide the same functionalities in a more efficient way.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-**NOTICE: pandas-td will be no longer maintained after June, 2019. Use [pytd](https://github.com/treasure-data/pytd) instead.** 
+**NOTICE: pandas-td will be no longer maintained after June 2019. Use [pytd](https://github.com/treasure-data/pytd) instead.** 
 
-The alternative tool offers pandas-td-compatible functions that provide the same functionalities in a more efficient way.
+See a [guide to replacing pandas-td with pytd](https://github.com/treasure-data/pytd#how-to-replace-pandas-td) for more information.
 
 # Pandas-TD [deprecated]
 


### PR DESCRIPTION
Very initial version of [pytd](https://github.com/treasure-data/pytd), a pandas-td alternative client tool, has been released: https://pypi.org/project/pytd/0.3.0/

It's time to add a note to README for upcoming retirement of this pandas-td package.

https://github.com/treasure-data/pytd/issues/4