### PR TITLE
Update deprecation notice per pytd v1 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-**NOTICE: pandas-td will be no longer maintained after June 2019. Use [pytd](https://github.com/treasure-data/pytd) instead.** 
+**NOTICE: pandas-td is no longer maintained. Use [pytd](https://github.com/treasure-data/pytd) instead.** 
 
-See a [guide to replacing pandas-td with pytd](https://github.com/treasure-data/pytd#how-to-replace-pandas-td) for more information.
+See a [guide to replacing pandas-td with pytd](https://github.com/treasure-data/pytd#how-to-replace-pandas-td) and its [official documentation](https://support.treasuredata.com/hc/en-us/sections/360003775873-Python-Library-Reference-for-pytd-pandas-td-) for more information.
 
 # Pandas-TD [deprecated]
 


### PR DESCRIPTION
pandas-td has officially been deprecated since [pytd v1](https://pypi.org/project/pytd/1.0.0/) becomes available.