### PR TITLE
Remove encoding argument.

### DIFF
--- a/pandas_td/td.py
+++ b/pandas_td/td.py
@@ -316,7 +316,7 @@ class ResultProxy(object):
             return ""
 
     def __iter__(self):
-        for record in msgpack.Unpacker(self, encoding="utf-8"):
+        for record in msgpack.Unpacker(self):
             yield record
 
     def _parse_dates(self, frame, parse_dates):


### PR DESCRIPTION
ref: https://github.com/treasure-data/pandas-td/issues/14

Just remove the `encoding` argument from `__iter__` funtion.
Probably this is not the best approach for #14 but suggest one way to approach.